### PR TITLE
Add an option to control image distortion

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ svg2img(svgString, function(error, buffer) {
 
 //2. convert from svg's base64 string
 svg2img(
-    'data:image/svg+xml;base64,'+ btoa(svgString), 
+    'data:image/svg+xml;base64,'+ btoa(svgString),
     function(error, buffer) {
         fs.writeFileSync('foo2.png', buffer);
 });
@@ -54,7 +54,7 @@ svg2img(__dirname+'/foo.svg', function(error, buffer) {
 
 //4. convert from a remote file
 svg2img(
-    'https://upload.wikimedia.org/wikipedia/commons/a/a0/Svg_example1.svg', 
+    'https://upload.wikimedia.org/wikipedia/commons/a/a0/Svg_example1.svg',
     function(error, buffer) {
         fs.writeFileSync('foo4.png', buffer);
 });
@@ -72,6 +72,27 @@ You can scale the svg by giving width and height.
 svg2img(__dirname+'/foo.svg', {'width':800, 'height':600} ,function(error, buffer) {
     fs.writeFileSync('foo.png', buffer);
 });
+```
+
+By default, the aspect ratio isn't preserved when scaling (same as `preserveAspectRatio="none"`). You can change it using `preserveAspectRatio` option. It can be `true` to keep original value or any other value to replace with.
+```javascript
+// use original preserveAspectRatio
+svg2img(
+    __dirname+'/foo.svg',
+    {width:800, height:600, preserveAspectRatio:true},
+    function(error, buffer) {
+        fs.writeFileSync('foo.png', buffer);
+    }
+);
+
+// use custom preserveAspectRatio
+svg2img(
+    __dirname+'/foo.svg',
+    {width:800, height:600, preserveAspectRatio:'xMinYMid meet'},
+    function(error, buffer) {
+        fs.writeFileSync('foo.png', buffer);
+    }
+);
 ```
 
 ## Run the Test

--- a/index.js
+++ b/index.js
@@ -74,14 +74,20 @@ function scale(svgContent, w, h, preserveAspectRatio) {
         }
     }
     svgTag = svgTag.join('').replace(/\n/g, ' ').replace(/\r/g, '');
-    var originalAspectRatio;
-    if (preserveAspectRatio && / preserveAspectRatio\W/.test(svgContent)) {
-        var quoChar = svgTag.match(/ preserveAspectRatio\s*=\s*(['"])/);
-        if (quoChar) {
-            quoChar = quoChar[1];
-            var aspectRatio = svgTag.match(new RegExp(' preserveAspectRatio\\s*=\\s*' + quoChar + '([^' + quoChar + ']*)'));
-            if (aspectRatio && aspectRatio[1]) {
-                originalAspectRatio = aspectRatio[1].replace(/^\s*(\S.*\S)\s*$/, '"$1"');
+    var finalAspectRatio;
+    if (preserveAspectRatio) {
+        if (typeof preserveAspectRatio === 'string') {
+            finalAspectRatio = '"' + preserveAspectRatio + '"';
+        } else {
+            if (/ preserveAspectRatio\W/.test(svgContent)) {
+                var quoChar = svgTag.match(/ preserveAspectRatio\s*=\s*(['"])/);
+                if (quoChar) {
+                    quoChar = quoChar[1];
+                    var aspectRatio = svgTag.match(new RegExp(' preserveAspectRatio\\s*=\\s*' + quoChar + '([^' + quoChar + ']*)'));
+                    if (aspectRatio && aspectRatio[1]) {
+                        finalAspectRatio = aspectRatio[1].replace(/^\s*(\S.*\S)\s*$/, '"$1"');
+                    }
+                }
             }
         }
     }
@@ -113,7 +119,7 @@ function scale(svgContent, w, h, preserveAspectRatio) {
     if (!props['viewBox']) {
         props['viewBox'] = '"'+[0,0,ow?ow:w,oh?oh:h].join(' ')+'"';
     }
-    props['preserveAspectRatio'] = originalAspectRatio || '"none"';
+    props['preserveAspectRatio'] = finalAspectRatio || '"none"';
 
     // update width and height in style attribute
     if (props['style'] && props['style'].length > 2) {

--- a/test/fy.svg
+++ b/test/fy.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" pointer-events="none" width="50" height="50" style="width: 50px; height: 50px; background-color: #CDDC39;">
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio='xMidYMid meet' pointer-events="none" width="50" height="50" style="width: 50px; height: 50px; background-color: #CDDC39;">
   <text text-anchor="middle" y="50%" x="50%" dy="0.36em" pointer-events="auto" fill="#ffffff" font-family="Helvetica, Arial, Lucida Grande, sans-serif" style="font-weight: 400; font-size: 28px;">
     FY
   </text>

--- a/test/specs.js
+++ b/test/specs.js
@@ -33,6 +33,15 @@ describe('Convert SVG', function () {
         })
     });
 
+    it('convert a svg file and scale it, keep preserveAspectRatio',function(done) {
+        svg2img(__dirname+'/ph.svg', {'width':400, 'height':400, preserveAspectRatio:true}, function(error, data) {
+            expect(error).not.to.be.ok();
+            expect(Buffer.isBuffer(data)).to.be.ok();
+            expect(data.length).to.be.above(0);
+            done();
+        })
+    });
+
     it('convert a remote svg file to png',function(done) {
         this.timeout(5000);
         svg2img('https://upload.wikimedia.org/wikipedia/commons/a/a0/Svg_example1.svg', function(error, data) {
@@ -76,7 +85,7 @@ describe('Convert SVG', function () {
 
     it('convert a svg with an image', function (done) {
         var imageUrl = 'https://zh.wikipedia.org/static/images/project-logos/zhwiki-hans.png';
-        Image64.encode(imageUrl, {}, function (err, base64) {            
+        Image64.encode(imageUrl, {}, function (err, base64) {
             var svgString = util.format('<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="540" height="258" ' +
                 'viewBox="0 0 540 258"><image width="540" height="258" x="0" y="0" href="%s"></image></svg>', 'data:image/png;base64,' + base64.toString('base64'));
             svg2img(svgString, function(error, data) {


### PR DESCRIPTION
Using `width` and `height` options can give a distorted image. This PR adds the `preserveAspectRatio` option to control it. I updated README for details.