### PR TITLE
Auto publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,23 +3,26 @@
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
 version: 2
+
+defaults: &defaults
+  working_directory: ~/repo
+  docker:
+    # specify the version you desire here
+    - image: circleci/node:8.11.4
+    # Specify service dependencies here if necessary
+    # CircleCI maintains a library of pre-built images
+    # documented at https://circleci.com/docs/2.0/circleci-images/
+    # - image: circleci/mongo:3.4.4
+
 jobs:
   build:
-    docker:
-      # specify the version you desire here
-      - image: circleci/node:8.11.4
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/mongo:3.4.4
-
-    working_directory: ~/repo
-
+    <<: *defaults
     steps:
       - checkout
 
-      - run: sudo apt install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+      - run:
+          name: Install build deps
+          command: sudo apt install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 
       # Download and cache dependencies
       - restore_cache:
@@ -36,6 +39,41 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
 
       # run tests!
-      - run: yarn test
+      - run:
+          name: Run tests
+          command: yarn test
 
+      - persist_to_workspace:
+          root: ~/repo
+          paths: .
 
+  deploy:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/repo
+      - run:
+          name: Authenticate with registry
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+      - run:
+          name: Publish package
+          command: npm publish
+
+workflows:
+  version: 2
+  build-and-deploy:
+    jobs:
+      - build:
+          # run job `build` for all branches and versioned tags
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+      - deploy:
+          requires:
+            - build
+          # run job `deploy` for no branches and only versioned tags
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svg2img",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A high-performance in-memory convertor to convert svg to png/jpeg images for Node. ",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
首先需要到CircleCI的`project settings`界面添加一个环境变量`NPM_TOKEN`.

这次增加了版本号, 所以合并后只需要tag一下即可.
比如
1. 运行:
```
git tag v0.4.1
git push --tags
```
2. 在GitHub的Release界面tag

即可发布v0.4.1

以后发布的话, 就可以
```
npm version 1.0.0 # 会自动生成一个v1.0.0的tag
git push --follow-tags
```