### PR TITLE
Type the no-option version of function call

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,5 +14,6 @@ export interface svg2imgOptions {
   quality?: number;
 }
 
-declare const svg2img: (svg: string, options: svg2imgOptions | Callback, callback: Callback) => void;
+function svg2img(svg: string, options: svg2imgOptions, callback: Callback): void;
+function svg2img(svg: string, callback: Callback): void;
 export default svg2img;


### PR DESCRIPTION
When no option specified, missing 3rd parameter error is shown.