### PR TITLE
Fix missing 'declare' modifiers on TypeScript function declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,6 @@ export interface svg2imgOptions {
   quality?: number;
 }
 
-function svg2img(svg: string, options: svg2imgOptions, callback: Callback): void;
-function svg2img(svg: string, callback: Callback): void;
+declare function svg2img(svg: string, options: svg2imgOptions, callback: Callback): void;
+declare function svg2img(svg: string, callback: Callback): void;
 export default svg2img;


### PR DESCRIPTION
PR #34 inadvertently introduced an error that made the typings unusable. On compilation, the TypeScript compiler errors:

```
node_modules/svg2img/index.d.ts:17:1 - error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.
```

This PR fixes the problem by adding the missing 'declare' modifiers on the function declarations.