### PR TITLE
Adds png compression

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,7 @@ export interface svg2imgOptions {
   preserveAspectRatio?: boolean | string;
   format?: Format;
   quality?: number;
+  compressionLevel?: number;
 }
 
 declare function svg2img(svg: string, options: svg2imgOptions, callback: Callback): void;

--- a/index.js
+++ b/index.js
@@ -47,7 +47,9 @@ function svg2img(svg, options, callback) {
                 quality: options['quality'] // JPEG quality (0-100) default: 75
             });
         } else {
-            stream = canvas.createPNGStream();
+            stream = canvas.createPNGStream({
+                compressionLevel: options['compressionLevel']
+            });
         }
         var data = [];
         var pos = 0;


### PR DESCRIPTION
For a project I needed to be able specify the png compression level. I noticed that node canvas supports an option for this, so I added the option to the svg2imgoptions and pass it to canvas