### PR TITLE
fix!: use === instead of >= for `indexOf`

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,12 +172,15 @@ function loadSVGContent(svg, callback) {
     if (Buffer.isBuffer(svg)) {
         svg = svg.toString('utf-8');
     }
-    if (svg.indexOf('data:image/svg+xml;base64,') >= 0) {
-        callback(null,atob(svg.substring('data:image/svg+xml;base64,'.length)));
+    
+    const base64Scheme = 'data:image/svg+xml;base64,';
+
+    if (svg.indexOf(base64Scheme) === 0) {
+        callback(null,atob(svg.substring(base64Scheme.length)));
     } else if (svg.indexOf('<svg') >= 0) {
-        callback(null, svg);
+        callback(null, svg.substring(svg.indexOf('<svg')));
     } else {
-        if (svg.indexOf('http://')>=0 || svg.indexOf('https://')>=0) {
+        if (svg.indexOf('http://')===0 || svg.indexOf('https://')===0) {
             loadRemoteImage(svg, callback);
         } else {
             fs.readFile(svg, function(error, data) {

--- a/test/atob.svg
+++ b/test/atob.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="97" height="20" role="img"
+  aria-label="npm: v1.9.0">
+  <title>npm: v1.9.0</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"></stop>
+    <stop offset="1" stop-opacity=".1"></stop>
+  </linearGradient>
+  <clipPath id="r">
+    <rect width="97" height="20" rx="3" fill="#fff"></rect>
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect width="52" height="20" fill="#555"></rect>
+    <rect x="52" width="45" height="20" fill="#007ec6"></rect>
+    <rect width="97" height="20" fill="url(#s)"></rect>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif"
+    text-rendering="geometricPrecision" font-size="110">
+    <image x="5" y="3" width="14" height="14"
+      xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0MCA0MCI+PHBhdGggZD0iTTAgMGg0MHY0MEgwVjB6IiBmaWxsPSIjY2IwMDAwIi8+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTcgN2gyNnYyNmgtN1YxNGgtNnYxOUg3eiIvPjwvc3ZnPgo=">
+    </image><text aria-hidden="true" x="355" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)"
+      textLength="250">npm</text><text x="355" y="140" transform="scale(.1)" fill="#fff"
+      textLength="250">npm</text><text aria-hidden="true" x="735" y="150" fill="#010101" fill-opacity=".3"
+      transform="scale(.1)" textLength="350">v1.9.0</text><text x="735" y="140" transform="scale(.1)" fill="#fff"
+      textLength="350">v1.9.0</text>
+  </g>
+</svg>

--- a/test/specs.js
+++ b/test/specs.js
@@ -62,6 +62,16 @@ describe('Convert SVG', function () {
         })
     });
 
+    it('convert a svg string with data URI to png',function(done) {
+        var svg = fs.readFileSync(__dirname+'/atob.svg');
+        svg2img(svg, null, function(error, data) {
+            expect(error).not.to.be.ok();
+            expect(Buffer.isBuffer(data)).to.be.ok();
+            expect(data.length).to.be.above(0);
+            done();
+        })
+    });
+
     it('convert a svg string to jpg',function(done) {
         var svg = fs.readFileSync(__dirname+'/ph.svg');
         svg2img(svg, {format:'jpeg'} ,function(error, data) {


### PR DESCRIPTION
A breaking change.

Use === 0 for matching the preceding part exactly. The previous implicit substring behavior, imo, is very misleading and error-causing, not to mention that it is totally missing in documentation.

This pull request is another approach for #52,  just choose the one you prefer.
