### PR TITLE
fix(types): format types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,6 @@
 type Callback = (err: any, buffer: any) => any;
 
-declare enum Format {
-  jpeg = 'jpeg',
-  jpg = 'jpg',
-  png = 'png',
-}
+type Format = 'jpeg' | 'jpg' | 'png';
 
 export interface svg2imgOptions {
   resvg?: ResvgRenderOptions;


### PR DESCRIPTION
The enum type `Format` is useless, there're no intellisense in VSCode. We should use plain string definitions.

目前代码的写法无法智能提示、且写 format: 'png' 会报错、因为它不认这是那个枚举类型