### PR TITLE
Fix: Images with external urls are not loaded

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,11 @@ var fs = require('fs');
 var atob = require('atob');
 var http = require('http');
 var https = require('https');
+var fetch = require("node-fetch")
 
 var jimp = require('jimp-compact');
 var { Resvg } = require('@resvg/resvg-js');
+var { promisify } = require('util');
 
 /**
  * Main method
@@ -44,6 +46,31 @@ function svg2img(svg, options, callback) {
                 options.resvg.background = '#fff';
             }
             var resvg = new Resvg(content, options.resvg);
+
+            // Load images
+            await Promise.all(
+                resvg.imagesToResolve().map(async url => {
+                    try {
+                        var img = await fetch(url);
+                        var imgType = img.headers.get('content-type')
+
+                        // Convert image links pointing to svg files to png
+                        if(imgType.match('svg')){ 
+                            var buffer = await svg2imgAsync(await img.text(), {})
+                        }
+                        else{
+                            var arrayBuffer = await img.arrayBuffer()
+                            var buffer = Buffer.from(arrayBuffer);
+                        }
+
+                        resvg.resolveImage(url, buffer);
+
+                    } catch (err) {
+                        console.warn("Error loading", url, err.message);
+                    }
+                })
+            );
+
             pngData = resvg.render();
         } catch (error) {
             callback(error);
@@ -116,5 +143,5 @@ function isFunction(func) {
     return typeof func === 'function' || (func.constructor !== null && func.constructor == Function);
 }
 
+var svg2imgAsync = promisify(svg2img)
 exports = module.exports = svg2img;
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@resvg/resvg-js": "^2.1.0",
         "atob": "^2.0.0",
         "btoa": "^1.1.2",
-        "jimp-compact": "^0.16.1-2"
+        "jimp-compact": "^0.16.1-2",
+        "node-fetch": "^2.7.0"
       },
       "devDependencies": {
         "expect.js": "^0.3.1",
@@ -1195,6 +1196,25 @@
         "request": "2.88.0"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1514,6 +1534,11 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -1572,6 +1597,20 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -2615,6 +2654,14 @@
         "request": "2.88.0"
       }
     },
+    "node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -2845,6 +2892,11 @@
         "punycode": "^1.4.1"
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -2892,6 +2944,20 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "@resvg/resvg-js": "^2.1.0",
     "atob": "^2.0.0",
     "btoa": "^1.1.2",
-    "jimp-compact": "^0.16.1-2"
+    "jimp-compact": "^0.16.1-2",
+    "node-fetch": "^2.7.0"
   },
   "engines": {
     "node": ">= 10"


### PR DESCRIPTION
node-canvas was able to load images with external urls, but `@resvg/resvg-js` does not do so automatically.
This PR intends to close the gap 

1. Preloads images with external urls before resvg renders the svg
2. Allows images to point to external svg images as well